### PR TITLE
fix >= redux@7.2.5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ function fromJS(data: object): Neox {
 
   state.set = (key: string, value: any) => {
     values.set(key, value);
-    return state;
+    return { ...state };
   }
 
   return state;


### PR DESCRIPTION
From React-Redux v7.2.5 and beyond, Neox has been broken, probably because of `useSelector` changes. This is a temporary fix for that.

Check React-Redux changelog: https://github.com/reduxjs/react-redux/releases/tag/v7.2.5